### PR TITLE
Add button accessibility

### DIFF
--- a/packages/wired-button/wired-button.js
+++ b/packages/wired-button/wired-button.js
@@ -13,12 +13,6 @@ export class WiredButton extends LitElement {
     super();
     this.elevation = 1;
     this.disabled = false;
-    this.addEventListener('keydown', (event) => {
-      if ((event.keyCode === 13) || (event.keyCode === 32)) {
-        event.preventDefault();
-        this.click();
-      }
-    });
   }
 
   _createRoot() {
@@ -85,14 +79,10 @@ export class WiredButton extends LitElement {
       }
     </style>
     <slot></slot>
-    <div class="overlay" tabIndex="${this._getIndex()}" role="button">
+    <div class="overlay">
       <svg id="svg"></svg>
     </div>
     `;
-  }
-
-  _getIndex() {
-    return this.disabled ? -1 : 0;
   }
 
   _onDisableChange() {
@@ -112,6 +102,14 @@ export class WiredButton extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     setTimeout(() => this._didRender());
+    this.addEventListener('keydown', (event) => {
+      if ((event.keyCode === 13) || (event.keyCode === 32)) {
+        event.preventDefault();
+        this.click();
+      }
+    });
+    this.setAttribute('role', 'button');
+    this.setAttribute('aria-label', this.innerHTML);
   }
 
   _didRender() {
@@ -132,8 +130,7 @@ export class WiredButton extends LitElement {
     }
     this.classList.remove('pending');
 
-    const overlay = this.shadowRoot.querySelector('.overlay');
-    overlay.setAttribute('aria-label', this.innerHTML);
+    this.tabIndex = this.disabled ? -1 : (this.tabIndex || 0);
   }
 }
 

--- a/packages/wired-button/wired-button.js
+++ b/packages/wired-button/wired-button.js
@@ -16,7 +16,7 @@ export class WiredButton extends LitElement {
   }
 
   _createRoot() {
-    const root = this.attachShadow({ mode: 'open', delegatesFocus: true });
+    const root = this.attachShadow({ mode: 'open' });
     this.classList.add('pending');
     return root;
   }
@@ -40,7 +40,6 @@ export class WiredButton extends LitElement {
         flex-direction: column;
         text-align: center;
         display: inline-flex;
-        outline: none;
       }
 
       :host(.pending) {
@@ -130,7 +129,7 @@ export class WiredButton extends LitElement {
     }
     this.classList.remove('pending');
 
-    this.tabIndex = this.disabled ? -1 : (this.tabIndex || 0);
+    this.tabIndex = this.disabled ? -1 : (this.getAttribute('tabIndex') || 0);
   }
 }
 

--- a/packages/wired-button/wired-button.js
+++ b/packages/wired-button/wired-button.js
@@ -129,7 +129,7 @@ export class WiredButton extends LitElement {
     }
     this.classList.remove('pending');
 
-    this.tabIndex = this.disabled ? -1 : (this.getAttribute('tabIndex') || 0);
+    this.tabIndex = this.disabled ? -1 : (this.getAttribute('tabindex') || 0);
   }
 }
 

--- a/packages/wired-button/wired-button.js
+++ b/packages/wired-button/wired-button.js
@@ -13,7 +13,12 @@ export class WiredButton extends LitElement {
     super();
     this.elevation = 1;
     this.disabled = false;
-
+    this.addEventListener('keydown', (event) => {
+      if ((event.keyCode === 13) || (event.keyCode === 32)) {
+        event.preventDefault();
+        this.click();
+      }
+    });
   }
 
   _createRoot() {
@@ -43,22 +48,22 @@ export class WiredButton extends LitElement {
         display: inline-flex;
         outline: none;
       }
-    
+
       :host(.pending) {
         opacity: 0;
       }
-    
+
       :host(:active) path {
         transform: scale(0.97) translate(1.5%, 1.5%);
       }
-    
+
       :host(.disabled) {
         opacity: 0.6 !important;
         background: rgba(0, 0, 0, 0.07);
         cursor: default;
         pointer-events: none;
       }
-    
+
       .overlay {
         position: absolute;
         top: 0;
@@ -67,11 +72,11 @@ export class WiredButton extends LitElement {
         bottom: 0;
         pointer-events: none;
       }
-    
+
       svg {
         display: block;
       }
-    
+
       path {
         stroke: currentColor;
         stroke-width: 0.7;
@@ -80,10 +85,14 @@ export class WiredButton extends LitElement {
       }
     </style>
     <slot></slot>
-    <div class="overlay">
+    <div class="overlay" tabIndex="${this._getIndex()}" role="button">
       <svg id="svg"></svg>
     </div>
     `;
+  }
+
+  _getIndex() {
+    return this.disabled ? -1 : 0;
   }
 
   _onDisableChange() {
@@ -122,6 +131,9 @@ export class WiredButton extends LitElement {
       (wired.line(svg, s.width + (i * 2), s.height + (i * 2), s.width + (i * 2), i * 2)).style.opacity = (75 - (i * 10)) / 100;
     }
     this.classList.remove('pending');
+
+    const overlay = this.shadowRoot.querySelector('.overlay');
+    overlay.setAttribute('aria-label', this.innerHTML);
   }
 }
 


### PR DESCRIPTION
@pshihn here's a PR for making the wired-button accessible. Can you have a look? This was way more difficult than I thought 😁 

I ran into several issues because I didn't really understand how to use lit-element:
1. not sure where the accessibility attributes should actually go, I added them to the div in the shadow dom. I noticed that if I add them directly on the wired-button element they wouldn't have any effect.
2. not sure how to get the innerHTML of the wired-button element to set it as `aria-label`, so I added it in the `_didRender` method, because there I had access to the innerHTML.
3. is it ok if I add the `keydown` event listener in the constructor? 

Thank you!