### PR TITLE
fix: set value when there is shadowRoot but no input

### DIFF
--- a/packages/wired-input/src/wired-input.ts
+++ b/packages/wired-input/src/wired-input.ts
@@ -87,10 +87,10 @@ export class WiredInput extends WiredBase {
       const input = this.input;
       if (input) {
         input.value = v;
+        return;
       }
-    } else {
-      this.pendingValue = v;
     }
+    this.pendingValue = v;
   }
 
   firstUpdated() {

--- a/packages/wired-textarea/src/wired-textarea.ts
+++ b/packages/wired-textarea/src/wired-textarea.ts
@@ -84,10 +84,10 @@ export class WiredTextarea extends WiredBase {
       const input = this.textarea;
       if (input) {
         input.value = v;
+        return;
       }
-    } else {
-      this.pendingValue = v;
     }
+    this.pendingValue = v;
   }
 
   firstUpdated() {


### PR DESCRIPTION
## current behavior
the value is lost if it set between generating `shadowRoot` and appending `input` element.

## expected behavior
the value should be set to `pendingValue` in case of `shadowRoot exist & input doesn't exist`.
