### PR TITLE
Improve bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7804,6 +7804,45 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
       "dev": true
     },
+    "minify-html-literals": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.0.tgz",
+      "integrity": "sha512-Ivfo8rDAF50VQv2FRln4e8uCbkZGis4YnxDdr8pNVhX3touZbYTWuXc7Qshq1YVXwX0xDazNRvQYvl8UVLgoIQ==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier": "^3.5.3",
+        "clean-css": "^4.2.1",
+        "html-minifier": "^4.0.0",
+        "magic-string": "^0.25.0",
+        "parse-literals": "^1.2.0"
+      },
+      "dependencies": {
+        "html-minifier": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+          "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+          "dev": true,
+          "requires": {
+            "camel-case": "^3.0.0",
+            "clean-css": "^4.2.1",
+            "commander": "^2.19.0",
+            "he": "^1.2.0",
+            "param-case": "^2.1.1",
+            "relateurl": "^0.2.7",
+            "uglify-js": "^3.5.1"
+          }
+        },
+        "magic-string": {
+          "version": "0.25.7",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+          "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.4"
+          }
+        }
+      }
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -8609,6 +8648,15 @@
       "requires": {
         "error-ex": "^1.3.1",
         "json-parse-better-errors": "^1.0.1"
+      }
+    },
+    "parse-literals": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/parse-literals/-/parse-literals-1.2.0.tgz",
+      "integrity": "sha512-gh4zPwvFSXx9ginX8lu9MP3OPHN3VV12PXI8IXD6oMCklFqM82pfbU9e/PKf9r7oLpbqlDSDyHYSVlxxuq3Iew==",
+      "dev": true,
+      "requires": {
+        "typescript": "^2.9.2 || ^3.0.0"
       }
     },
     "parse-path": {
@@ -9761,6 +9809,22 @@
         }
       }
     },
+    "rollup-plugin-analyzer": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-analyzer/-/rollup-plugin-analyzer-3.2.2.tgz",
+      "integrity": "sha512-rRNOaykvnniNmByeaYuhrnMSwAmYduvGy1q2rBchRjGL/bEtEVr2WogKMQ0po8QbnwcsYaiQacYFxsvGTnw6Iw==",
+      "dev": true
+    },
+    "rollup-plugin-minify-html-literals": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-1.2.3.tgz",
+      "integrity": "sha512-7Oj1v5fa8eT0aQMsOUq9gO1E60MqGgeFMTMyFLYpzBP5q83gRSOp0YDIa/iPoItx9WBrciuNqqFdThY6YvUwQA==",
+      "dev": true,
+      "requires": {
+        "minify-html-literals": "^1.3.0",
+        "rollup-pluginutils": "^2.8.2"
+      }
+    },
     "rollup-plugin-node-resolve": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
@@ -10363,6 +10427,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spdx-correct": {
@@ -11391,7 +11461,6 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.7.tgz",
       "integrity": "sha512-FeSU+hi7ULYy6mn8PKio/tXsdSXN35lm4KgV2asx00kzrLU9Pi3oAslcJT70Jdj7PHX29gGUPOT6+lXGBbemhA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "commander": "~2.20.3",
         "source-map": "~0.6.1"
@@ -11401,8 +11470,7 @@
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "lerna-update-wizard": "^0.17.7",
     "polyserve": "^0.27.15",
     "rollup": "^1.32.1",
+    "rollup-plugin-analyzer": "^3.2.2",
+    "rollup-plugin-minify-html-literals": "^1.2.3",
     "rollup-plugin-node-resolve": "^5.2.0",
     "rollup-plugin-terser": "^5.3.0",
     "tslint": "^5.20.1",

--- a/packages/wired-calendar/src/wired-calendar.ts
+++ b/packages/wired-calendar/src/wired-calendar.ts
@@ -1,4 +1,6 @@
 import { LitElement, customElement, property, TemplateResult, html, css, CSSResult, PropertyValues } from 'lit-element';
+import { styleMap } from 'lit-html/directives/style-map';
+import { classMap } from 'lit-html/directives/class-map';
 import { ellipse, line, rectangle, fire } from 'wired-lib';
 
 interface AreaSize {
@@ -177,6 +179,17 @@ export class WiredCalendar extends LitElement {
   }
 
   render(): TemplateResult {
+    const tblHeadHeight = {height: `${this.tblHeadHeight}px`};
+    const tblStyle = {
+      width: `${this.calendarRefSize.width}px`,
+      height: `${this.calendarRefSize.height}px`,
+      border: `${TABLE_PADDING}px solid transparent`,
+    };
+    const tblColWidth = {width: `${this.tblColWidth}px`};
+    const tblRowHeight = {height: `${this.tblRowHeight}px`}
+    const dayNames = this.weekdays_short.map((d) =>
+      html`<th style=${styleMap(tblColWidth)}>${this.initials ? d[0] : d}</th>`)
+
     /*
     * Template to render a one month calendar
     *
@@ -189,29 +202,20 @@ export class WiredCalendar extends LitElement {
     * ... (and svg tag) to draw over it.
     */
     return html`
-    <table style="width:${this.calendarRefSize.width}px;height:${this.calendarRefSize.height}px;border:${TABLE_PADDING}px solid transparent"
+    <table style=${styleMap(tblStyle)}
             @mousedown="${this.onItemClick}"
             @touchstart="${this.onItemClick}">
-      ${ /* 1st header row with calendar title and prev/next controls */ ''}
-      <tr class="top-header" style="height:${this.tblHeadHeight}px;">
+      <tr class="top-header" style=${styleMap(tblHeadHeight)}>
         <th id="prevCal" class="pointer" @click="${this.onPrevClick}">&lt;&lt;</th>
         <th colSpan="5">${this.monthYear}</th>
         <th id="nextCal" class="pointer" @click="${this.onNextClick}">&gt;&gt;</th>
       </tr>
-      ${ /* 2nd header row with the seven weekdays names (short or initials) */ ''}
-      <tr class="header" style="height:${this.tblHeadHeight}px;">
-        ${this.weekdays_short
-        .map((d) =>
-          html`<th style="width: ${this.tblColWidth};">${this.initials ? d[0] : d}</th>
-            `
-        )
-      }
+      <tr class="header" style=${styleMap(tblHeadHeight)}>
+        ${dayNames}
       </tr>
-      ${ /* Loop thru weeks building one row `<tr>` for each week */ ''}
       ${this.weeks
         .map((weekDays: CalendarCell[]) =>
-          html`<tr style="height:${this.tblRowHeight}px;">
-              ${ /* Loop thru weeekdays in each week building one data cell `<td>` for each day */ ''}
+          html`<tr style=${styleMap(tblRowHeight)}>
               ${weekDays
               .map((d: CalendarCell) =>
 
@@ -221,14 +225,14 @@ export class WiredCalendar extends LitElement {
                   // Render "selected" cell
                   html`
                             <td class="selected" value="${d.value}">
-                            <div style="width: ${this.tblColWidth}px; line-height:${this.tblRowHeight}px;">${d.text}</div>
+                            <div style=${styleMap({...tblColWidth, lineHeight: `${tblRowHeight}px`})}>${d.text}</div>
                             <div class="overlay">
                               <svg id="svgTD" class="selected"></svg>
                             </div></td>
                         ` :
                   // Render "not selected" cell
                   html`
-                            <td .className="${d.disabled ? 'disabled' : (d.dimmed ? 'dimmed' : '')}"
+                            <td class=${classMap({disabled: !!d.disabled, dimmed: !!d.dimmed})}
                                 value="${d.disabled ? '' : d.value}">${d.text}</td>
                         `}
                     `
@@ -236,10 +240,10 @@ export class WiredCalendar extends LitElement {
                 // This blank space left on purpose for clarity
 
               )
-            }${ /* End `weekDays` map loop */ ''}
+            }
             </tr>`
         )
-      }${ /* End `weeks` map loop */ ''}
+      }
     </table>
     <div class="overlay">
       <svg id="svg" class="calendar"></svg>

--- a/packages/wired-tabs/src/wired-tabs.ts
+++ b/packages/wired-tabs/src/wired-tabs.ts
@@ -1,5 +1,4 @@
 import { LitElement, customElement, property, css, TemplateResult, html, CSSResultArray, query } from 'lit-element';
-import { repeat } from 'lit-html/directives/repeat';
 import { BaseCSS } from 'wired-lib/lib/wired-base';
 
 interface WiredTabItem extends HTMLElement {
@@ -47,7 +46,7 @@ export class WiredTabs extends LitElement {
   render(): TemplateResult {
     return html`
     <div id="bar">
-      ${repeat(this.pages, (p) => p.name, (p) => html`
+      ${this.pages.map((p) => html`
       <wired-item role="tab" .value="${p.name}" .selected="${p.name === this.selected}" ?aria-selected="${p.name === this.selected}"
         @click="${() => this.selected = p.name}">${p.label || p.name}</wired-item>
       `)}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,7 @@
 import resolve from 'rollup-plugin-node-resolve';
 import { terser } from "rollup-plugin-terser";
+import analyze from 'rollup-plugin-analyzer';
+import minifyHTML from 'rollup-plugin-minify-html-literals';
 
 const input = 'packages/all/lib/wired-elements.js';
 const outDir = 'packages/all/lib';
@@ -33,11 +35,14 @@ export default [
     onwarn,
     plugins: [
       resolve(),
+      minifyHTML(),
       terser({
         output: {
           comments: false
         }
-      })
+      }),
+      analyze({filter: ({id}) => id.indexOf('lit-html') < 0
+      && id.indexOf('lit-element') < 0 }),
     ]
   },
   {


### PR DESCRIPTION
Hello,

## Idea
I'm not OBSESSED with bundle size, but the SMALLER the BETTER hey?

I think the main improvement can come from minifying the html and css in template string.
Luckily there is [a plugin that do just that](https://www.npmjs.com/package/rollup-plugin-minify-html-literals)! 

Here is a proof of concept. I slightly refactored the calendar, cause there were comments inside the html template, and other minor issues that were disturbing the minification process... Results below.

## First Results
Currently on master branch:
![image](https://user-images.githubusercontent.com/7101875/79729641-04a67080-82f0-11ea-9a6d-a9e4779ccf3c.png)


After minification (I've used minification only on `wired-elements-bundled.js`) :
![image](https://user-images.githubusercontent.com/7101875/79728003-88129280-82ed-11ea-901b-db78683f5d07.png)


So here is a ~10% improvement with the minify plugin, so I think it's a great opportunity :) 
Regards