### PR TITLE
Fix (calendar): Fixes display error due to locale first-weekday not Sunday #156

### DIFF
--- a/examples/calendar.html
+++ b/examples/calendar.html
@@ -58,17 +58,17 @@
 
     <!-- Calendar with some parameters -->
     <div class="item_wrapper">
-      <p>"fr" locale</p>
+      <p>"fr-FR" locale</p>
       <!-- Note: parameter dates not affected by locale -->
       <wired-calendar id="calendar2" elevation="1" firstdate="Apr 15, 2019" lastdate="Jul 15, 2019"
-        selected="Jul 4, 2019" locale="fr" initials>
+        selected="Jul 4, 2019" locale="fr-FR" initials>
       </wired-calendar>
     </div>
 
     <!-- Calendar with custom style and some parameters -->
     <div class="item_wrapper">
-      <p>"de" locale</p>
-      <wired-calendar id="calendar3" class="custom" firstdate="Apr 15, 2019" locale="de" initials>
+      <p>"de-DE" locale</p>
+      <wired-calendar id="calendar3" class="custom" firstdate="Apr 15, 2019" locale="de-DE" initials>
       </wired-calendar>
     </div>
   </div>


### PR DESCRIPTION
Issue #156 

Day number and day names were out of phase when locale first-day-of-the-week was not Sunday.
The problem is that the original code assumed Sunday as the first day of the week always.

### What has changed:

1. Accept locale _region_ like: `en-GB` and `de-DE`. Previously only the _language_ part was relevant, _region_ was ignored.
2. Compute _first weekday of the week_ depending on _region_.
3. Offset weekday names header **and** day number to keep phased by columns.

### What reviewer should know:
The future and easy way to get the locale first weekday is using `Intl.locale.weekInfo.firstDay` but is not supported by all major browsers yet, to date.
So that, it was obtained by a RegEx string to isolate the _locale region_ and with a extensive _region_ to _first weekday_ map.
Understand that this is a hardcoded solution that will cause maintenance debt. To overcome this, **both solutions were programmed** but the code of the _Intl.locale.weekInfo_ one was commented out for future use.
