### PR TITLE
[wired-combo] Handle large wired-item lists.

### DIFF
--- a/src/wired-combo.ts
+++ b/src/wired-combo.ts
@@ -102,6 +102,8 @@ export class WiredCombo extends LitElement {
         z-index: 1;
         box-shadow: 1px 5px 15px -6px rgba(0, 0, 0, 0.8);
         padding: 8px;
+        overflow: clip scroll;
+        max-height: 40vh;
       }
   
       ::slotted(wired-item) {


### PR DESCRIPTION
If the list of `<wired-item>`s is very large, the `<wired-card>` element used to display then is tall causing the items at the bottom to be below the window and unselectable.  This change limits the maximum size of the card to 40% of window height and makes the card scollable in order to reach the lower items.